### PR TITLE
Update Tracked Events to use an ID system instead of names

### DIFF
--- a/DEV/config/prov_files/trackr.sql
+++ b/DEV/config/prov_files/trackr.sql
@@ -27,13 +27,14 @@ SET time_zone = "+00:00";
 --
 
 CREATE TABLE IF NOT EXISTS `tracked_events` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
   `date_added` datetime NOT NULL,
   `name` varchar(255) NOT NULL,
   `type` varchar(255) NOT NULL,
   `description` varchar(255) NOT NULL,
   `image_url` varchar(255),
   `active` int(11) NOT NULL,
-  UNIQUE KEY `date_added` (`date_added`)
+  UNIQUE KEY `id` (`id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 --
@@ -52,24 +53,27 @@ INSERT INTO `tracked_events` (`date_added`, `name`, `type`, `description`, `imag
 --
 
 CREATE TABLE IF NOT EXISTS `Affect` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
   `date` datetime NOT NULL,
   `value` int(11) NOT NULL,
   `active` int(11) NOT NULL,
-  UNIQUE KEY `date` (`date`)
+  UNIQUE KEY `id` (`id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE IF NOT EXISTS `Activity` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
   `date` datetime NOT NULL,
   `value` int(11) NOT NULL,
   `active` int(11) NOT NULL,
-  UNIQUE KEY `date` (`date`)
+  UNIQUE KEY `id` (`id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 CREATE TABLE IF NOT EXISTS `Meditation` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
   `date` datetime NOT NULL,
   `value` int(11) NOT NULL,
   `active` int(11) NOT NULL,
-  UNIQUE KEY `date` (`date`)
+  UNIQUE KEY `id` (`id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 

--- a/html/controller/settings/settings_handler.php
+++ b/html/controller/settings/settings_handler.php
@@ -15,7 +15,7 @@ if (isset($_GET['view']) && $_GET['view'] == "true") {
 	// Show the details of the particular event
 	include ("../view/settings/edit_event.php");
 
-} elseif (isset($_GET['description']) && $_GET['origname'] == "Event Name") {
+} elseif (isset($_GET['description']) && $_GET['id'] == "") {
 
 	$event_manager->add_event ( $event_name, "binary", $_GET['description'] ) ;
 
@@ -23,37 +23,36 @@ if (isset($_GET['view']) && $_GET['view'] == "true") {
 	$event_manager->build_tables();
 
 	// Redirect to the overview page without query strings
-    // header("Location: http://www.health-dev.com/analytics/settings.php");
-    // exit;
+    header("Location: http://www.trackr-dev.com/analytics/settings.php");
+    exit;
 
 } elseif (isset($_GET['description'])) {
 
-	$event_manager->update_event ( $_GET['origname'], "name", $event_name );
-	$event_manager->update_event ( $_GET['origname'], "description", $_GET['description'] );
-
-	// $event_manager->update_event ( $_GET['origname'], "name", $event_name );
-	// $event_manager->update_event ( $_GET['origname'], "description", $_GET['description'] );
+	$event_manager->update_event ( $_GET['id'], "name", $event_name );
+	$event_manager->update_event ( $_GET['id'], "description", $_GET['description'] );
 
 	// Redirect to the overview page without query strings
-    // header("Location: http://www.health-dev.com/analytics/settings.php");
-    // exit;
+    header("Location: http://www.trackr-dev.com/analytics/settings.php");
+    exit;
 
 } elseif (isset($_GET['edit']) && $_GET['edit'] == "true") {
+
+	var_dump($_GET);
 
 	// If there's a disable query, mark the event as not active
 	if ($_GET['fields'] == "status" && $_GET['value'] == "disabled") {
 
-		$event_manager->update_event ( $event_name, "active", 0 );
+		$event_manager->update_event ( $_GET['id'], "active", 0 );
 
 	} elseif ($_GET['fields'] == "status" && $_GET['value'] == "enabled") {
 
-		$event_manager->update_event ( $event_name, "active", 1 );
+		$event_manager->update_event ( $_GET['id'], "active", 1 );
 
 	}
 	
 	// Redirect to the overview page without query strings
-    // header("Location: http://www.health-dev.com/analytics/settings.php");
-    // exit;
+    header("Location: http://www.trackr-dev.com/analytics/settings.php");
+    exit;
 
 }
 

--- a/html/model/events/event_manager.php
+++ b/html/model/events/event_manager.php
@@ -57,6 +57,7 @@ class event_manager extends db {
 
       // Create a new table for each event
       $sql = "CREATE TABLE IF NOT EXISTS `" . $event['name'] . "` (
+       `id` int(11) NOT NULL AUTO_INCREMENT,
         `date` datetime NOT NULL,
         `value` int(11) NOT NULL,
         `active` int(11) NOT NULL,

--- a/html/view/settings/edit_event.php
+++ b/html/view/settings/edit_event.php
@@ -19,7 +19,7 @@ $instruction = ($name == "Event Name") ? "Create Event" : "Update";
   <form method="GET">
 
 
-    <input type="hidden" name="origname" id="name" value="<?php echo $name ?>">
+    <input type="hidden" name="id" id="name" value="<?php echo $db->event_details[0]['id'] ?>">
 
     <div class="form-group">
       <label for="new_name">Event Name</label>
@@ -42,13 +42,13 @@ $instruction = ($name == "Event Name") ? "Create Event" : "Update";
       // Check whether to show the disable or enable button
       if ($db->event_details[0]['active'] === "1") { ?>
 
-        <a href="?edit=true&fields=status&value=disabled&event=<?php echo $db->event_details[0]['name']; ?>" class="btn btn-danger" role="button">
+        <a href="?edit=true&fields=status&value=disabled&id=<?php echo $db->event_details[0]['id']; ?>" class="btn btn-danger" role="button">
           <span class="glyphicon glyphicon-pause" aria-hidden="true"></span>&nbsp;&nbsp; Disable
         </a> 
 
       <?php } elseif ($db->event_details[0]['active'] === "0") { ?>
     
-        <a href="?edit=true&fields=status&value=enabled&event=<?php echo $db->event_details[0]['name']; ?>" class="btn btn-success" role="button">
+        <a href="?edit=true&fields=status&value=enabled&id=<?php echo $db->event_details[0]['id']; ?>" class="btn btn-success" role="button">
           <span class="glyphicon glyphicon-play" aria-hidden="true"></span>&nbsp;&nbsp; Enable
         </a> 
     


### PR DESCRIPTION
Originally, tracked events were managed by their names, this made updating names complicated.  Instead, numeric id's have been added as a unique key for all tables.

This PR includes updates for the event editing section to take advantage of this new id system